### PR TITLE
Improve feed UI with colorful grid

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,6 +1,6 @@
 body {
   font-family: 'Inter', sans-serif;
-  background-color: #f4f6f9;
+  background: linear-gradient(135deg, #e0f7fa 0%, #fce4ec 100%);
 }
 
 h1, h2 {
@@ -15,10 +15,37 @@ h1, h2 {
 }
 
 .table > thead {
-  background-color: #e9ecef;
+  background-color: #b0d4f1;
+  color: #ffffff;
 }
 
 .thumbnail:hover {
   cursor: pointer;
   opacity: 0.8;
+}
+
+.photo-grid .card {
+  border: none;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  position: relative;
+}
+
+.photo-grid .card-body {
+  background-color: #ffffffcc;
+}
+
+.photo-grid .card-text {
+  font-size: 0.85rem;
+}
+
+.play-icon {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 2rem;
+  color: rgba(255, 255, 255, 0.8);
+  pointer-events: none;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Default Title{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='images/flutter.svg') }}">

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,31 +12,19 @@
 
 {% block content %}
     <h2>Recent Detections</h2>
-    <table class="table table-hover table-striped">
-        <thead>
-        <tr>
-            <th scope="col">Detection Time</th>
-            <th scope="col">Common Name</th>
-            <th scope="col">Confidence</th>
-            <th scope="col">Thumbnail</th>
-        </tr>
-        </thead>
-        <tbody>
+    <div class="row row-cols-2 row-cols-md-4 row-cols-lg-6 g-3 photo-grid">
         {% for detection in recent_detections %}
-            <tr>
-                <td>{{ detection.detection_time }}</td>
-                <td>{{ detection.common_name }}</td>
-                <td>{{ '%.2f'|format(detection.score) }}</td>
-                <td>
-                    <img src="{{ url_for('frigate_thumbnail', frigate_event=detection.frigate_event) }}" alt="Thumbnail"
-     width="100" height="auto" class="thumbnail"
-     onload="checkTransparentImage(this)"
-     onclick="showSnapshot('{{ url_for('frigate_snapshot', frigate_event=detection.frigate_event) }}', '{{ url_for('frigate_clip', frigate_event=detection.frigate_event) }}')"/>
-                </td>
-            </tr>
+        <div class="col">
+            <div class="card h-100 border-0 shadow-sm position-relative">
+                <img src="{{ url_for('frigate_thumbnail', frigate_event=detection.frigate_event) }}" alt="Thumbnail" class="card-img-top thumbnail" onload="checkTransparentImage(this)" onclick="showVideoDirect('{{ url_for('frigate_clip', frigate_event=detection.frigate_event) }}')"/>
+                <span class="play-icon"><i class="fa-solid fa-circle-play"></i></span>
+                <div class="card-body p-2">
+                    <p class="card-text text-center mb-0">{{ detection.common_name }}</p>
+                </div>
+            </div>
+        </div>
         {% endfor %}
-        </tbody>
-    </table>
+    </div>
 
     <h2>Detection Summary</h2>
     <table class="table table-hover table-striped">

--- a/templates/modals_and_scripts.html
+++ b/templates/modals_and_scripts.html
@@ -8,7 +8,9 @@
             </div>
             <div class="modal-body">
                 <img id="snapshotImage" src="" alt="Snapshot" class="img-fluid mb-3"/>
-                <button type="button" class="btn btn-primary" onclick="showVideo()">View Video</button>
+                <button type="button" class="btn btn-primary" onclick="showVideo()">
+                    <i class="fa-solid fa-circle-play me-1"></i>View Video
+                </button>
             </div>
         </div>
     </div>
@@ -49,6 +51,14 @@
         videoClip.load();
         var snapshotModal = bootstrap.Modal.getInstance(document.getElementById("snapshotModal"));
         snapshotModal.hide();
+        var videoModal = new bootstrap.Modal(document.getElementById("videoModal"));
+        videoModal.show();
+    }
+
+    function showVideoDirect(clipUrl) {
+        var videoClip = document.getElementById("videoClip");
+        videoClip.src = clipUrl;
+        videoClip.load();
         var videoModal = new bootstrap.Modal(document.getElementById("videoModal"));
         videoModal.show();
     }


### PR DESCRIPTION
## Summary
- revamp landing page to show recent detections in a responsive grid
- add new `showVideoDirect` helper to open videos directly
- modernize colours and styling
- add Font Awesome icons and play overlays

## Testing
- `python -m py_compile webui.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685959bda4c8832385c65588bcfc93fa