### PR TITLE
Upgrade to Python 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.10
 RUN apt-get update && apt-get install ffmpeg libsm6 libxext6  -y
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -117,3 +117,6 @@ http://127.0.0.1:7766 or on http://yourserveraddress:7766
 
 **Docker Image**
 The image is on Docker Hub at https://hub.docker.com/r/mmcc73/whosatmyfeeder
+This project now targets **Python 3.10**. If you build the image yourself or
+run the code directly, ensure your environment uses Python 3.10 or later.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-Flask==2.3.2
-numpy==1.24.3
-opencv_python==4.7.0.72
-paho_mqtt==1.6.1
-PyYAML==6.0
-tflite_support==0.4.3
-requests==2.30.0
-Pillow==9.5.0
+Flask>=2.3.2
+numpy>=1.24.3
+opencv_python>=4.7.0.72
+paho_mqtt>=1.6.1
+PyYAML>=6.0
+tflite_support>=0.4.5
+requests>=2.30.0
+Pillow>=9.5.0


### PR DESCRIPTION
## Summary
- update Dockerfile to use python 3.10
- bump dependency versions in requirements.txt
- document Python 3.10 requirement in README

## Testing
- `python -m py_compile speciesid.py webui.py queries.py`

------
https://chatgpt.com/codex/tasks/task_e_685962668a5c83239beeb0d4776c25d9