### PR TITLE
Add React dashboard and API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Actually I'm populating it with the first 20 characters of the bird species comm
 field is currently limited to 20 characters
 * I also changed (improved, I hope) the UI significantly. I don't think there's any lost functionality.
 * The Web UI now uses Bootstrap 5.3 with modern fonts for a sleeker look.
+* A lightweight React dashboard is available at `/dashboard` showing trending species.
+* New JSON API endpoints provide recent detections, daily summaries and trending data.
+* The `config.yml` now uses an `objects:` list so multiple animals can be tracked.
 
 ![screenshot](screenshot2.jpg)
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Actually I'm populating it with the first 20 characters of the bird species comm
 field is currently limited to 20 characters
 * I also changed (improved, I hope) the UI significantly. I don't think there's any lost functionality.
 * The Web UI now uses Bootstrap 5.3 with modern fonts for a sleeker look.
-* A lightweight React dashboard is available at `/dashboard` showing trending species.
-* New JSON API endpoints provide recent detections, daily summaries and trending data.
+* A lightweight React dashboard is available at `/dashboard` showing trending species and a line chart of daily detections.
+* New JSON API endpoints provide recent detections, daily summaries, trending data and daily detection counts.
 * The `config.yml` now uses an `objects:` list so multiple animals can be tracked.
 
 ![screenshot](screenshot2.jpg)

--- a/config/config.yml
+++ b/config/config.yml
@@ -7,7 +7,8 @@ frigate:
   main_topic: frigate
   camera:
     - birdcam
-  object: bird
+  objects:
+    - bird
 classification:
   model: model.tflite
   threshold: 0.7

--- a/queries.py
+++ b/queries.py
@@ -188,3 +188,28 @@ def trending_species(days=7, limit=5):
 
     conn.close()
     return results
+
+
+def daily_counts(days=7):
+    """Return detection counts for each of the last ``days`` days."""
+    conn = sqlite3.connect(DBPATH)
+    conn.row_factory = sqlite3.Row
+    cursor = conn.cursor()
+
+    query = """
+        SELECT DATE(detection_time) AS day, COUNT(*) AS detections
+        FROM detections
+        WHERE detection_time >= datetime('now', ?)
+        GROUP BY day
+        ORDER BY day ASC
+    """
+
+    cursor.execute(query, (f'-{int(days)} days',))
+    rows = cursor.fetchall()
+
+    results = []
+    for row in rows:
+        results.append({'date': row['day'], 'count': row['detections']})
+
+    conn.close()
+    return results

--- a/speciesid.py
+++ b/speciesid.py
@@ -94,8 +94,9 @@ def on_message(client, userdata, message):
         # Extract the 'after' element data and store it in a dictionary
         after_data = payload_dict.get('after', {})
 
+        target_objs = config['frigate'].get('objects') or [config['frigate'].get('object', 'bird')]
         if (after_data['camera'] in config['frigate']['camera'] and
-                after_data['label'] == 'bird'):
+                after_data['label'] in target_objs):
 
             frigate_event = after_data['id']
             frigate_url = config['frigate']['frigate_url']

--- a/templates/base.html
+++ b/templates/base.html
@@ -33,7 +33,9 @@
         </button>
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
             <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-
+                <li class="nav-item">
+                    <a class="nav-link" href="/dashboard"><i class="fa-solid fa-chart-column me-1"></i>Dashboard</a>
+                </li>
             </ul>
             {% block date_picker %}{% endblock %}
         </div>

--- a/templates/react_dashboard.html
+++ b/templates/react_dashboard.html
@@ -9,14 +9,36 @@
   <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
   <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
   <script type="text/babel">
     function App() {
       const [trending, setTrending] = React.useState([]);
+      const [counts, setCounts] = React.useState([]);
       React.useEffect(() => {
         fetch('/api/trending')
           .then(res => res.json())
           .then(data => setTrending(data));
+        fetch('/api/daily_counts')
+          .then(res => res.json())
+          .then(data => setCounts(data));
       }, []);
+      React.useEffect(() => {
+        if (counts.length === 0) return;
+        const ctx = document.getElementById('countChart');
+        new Chart(ctx, {
+          type: 'line',
+          data: {
+            labels: counts.map(d => d.date),
+            datasets: [{
+              label: 'Detections',
+              data: counts.map(d => d.count),
+              fill: false,
+              borderColor: '#0d6efd',
+            }]
+          },
+          options: {scales: {y: {beginAtZero: true}}}
+        });
+      }, [counts]);
       return (
         <div>
           <h2><i class="fa-solid fa-chart-line"></i> Trending Species</h2>
@@ -33,6 +55,8 @@
               ))}
             </tbody>
           </table>
+          <h2 className="mt-4"><i class="fa-solid fa-calendar-day"></i> Daily Detections</h2>
+          <canvas id="countChart" height="100"></canvas>
         </div>
       );
     }

--- a/templates/react_dashboard.html
+++ b/templates/react_dashboard.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+{% block title %}Dashboard{% endblock %}
+
+{% block content %}
+  <div id="root"></div>
+{% endblock %}
+
+{% block scripts %}
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <script type="text/babel">
+    function App() {
+      const [trending, setTrending] = React.useState([]);
+      React.useEffect(() => {
+        fetch('/api/trending')
+          .then(res => res.json())
+          .then(data => setTrending(data));
+      }, []);
+      return (
+        <div>
+          <h2><i class="fa-solid fa-chart-line"></i> Trending Species</h2>
+          <table className="table table-hover table-striped">
+            <thead>
+              <tr><th>Common Name</th><th>Detections</th></tr>
+            </thead>
+            <tbody>
+              {trending.map(sp => (
+                <tr key={sp.scientific_name}>
+                  <td>{sp.common_name}</td>
+                  <td>{sp.count}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
+    }
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+{% endblock %}

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -61,3 +61,11 @@ def test_recent_detections(tmp_path, monkeypatch):
     det = res[0]
     assert det["display_name"] == "passer domesticus"
     assert det["common_name"] == "House Sparrow"
+
+
+def test_daily_counts(tmp_path, monkeypatch):
+    data_db = tmp_path / "detections.db"
+    setup_detections_db(data_db)
+    monkeypatch.setattr(queries, "DBPATH", str(data_db))
+    counts = queries.daily_counts(5000)
+    assert counts == [{"date": "2024-01-01", "count": 1}]

--- a/tests/test_speciesid.py
+++ b/tests/test_speciesid.py
@@ -41,6 +41,7 @@ def test_setupdb_creates_table(tmp_path, monkeypatch):
     flask_mod.send_file = lambda *a, **k: None
     flask_mod.abort = lambda *a, **k: None
     flask_mod.send_from_directory = lambda *a, **k: None
+    flask_mod.jsonify = lambda *a, **k: {}
     sys.modules.setdefault('flask', flask_mod)
     yaml_mod = types.ModuleType('yaml')
     yaml_mod.safe_load = lambda f: {}

--- a/webui.py
+++ b/webui.py
@@ -13,6 +13,7 @@ from queries import (
     get_records_for_scientific_name_and_date,
     get_earliest_detection_date,
     trending_species,
+    daily_counts,
 )
 
 app = Flask(__name__)
@@ -140,6 +141,12 @@ def api_trending():
     days = int(request.args.get('days', 7))
     limit = int(request.args.get('limit', 5))
     return jsonify(trending_species(days, limit))
+
+
+@app.route('/api/daily_counts')
+def api_daily_counts():
+    days = int(request.args.get('days', 7))
+    return jsonify(daily_counts(days))
 
 
 @app.route('/dashboard')


### PR DESCRIPTION
## Summary
- introduce trending_species query and config updates
- expose new JSON API endpoints and React-based dashboard
- make target objects configurable
- adjust tests for flask jsonify stub

## Testing
- `python agents.py`

------
https://chatgpt.com/codex/tasks/task_e_685a266b6d988323901240d57c60f2b5